### PR TITLE
Fixed HOST_NAME_MAX error, and fixed CTRL-C bug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 /* The main loop of the sheesh shell */
 #include <stdio.h>
 #include <stdlib.h>
+#include <signal.h>
 #include "input.h"
 #include "split.h"
 #include "exec.h"
@@ -35,10 +36,14 @@ void sheesh_loop(void)
     } while (status);
 }
 
+/* Do nothing for SIGINT (ctrl-c) */
+void sigint_nothing() { return; }
+
 int main(void)
 {
     log_user();      /* Get the current username and host name*/
     history_check(); /* Test if the history file is accessible */
+    signal(SIGINT, sigint_nothing); /* Catch SIGINT and do nothing (ctrl-c) */
     sheesh_loop();   /* Start the shell loop */
     return 0;
 }

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -11,7 +11,14 @@ int prompt_mode = 0;
 const char *hme;
 
 static char cwd[PATH_MAX];
+
+#ifndef HOST_NAME_MAX
+/* HOST_NAME_MAX not available on some platforms */
+static char hst[_POSIX_HOST_NAME_MAX + 1 /* \0 */];
+#else
 static char hst[HOST_NAME_MAX + 1 /* \0 */];
+#endif
+
 static const char *usr;
 
 void prompt(void)


### PR DESCRIPTION
HOST_NAME_MAX is undefined on some platforms I have come to find out (my platform). So I added a conditional macro for _POSIX_HOST_NAME_MAX if the original is not defined.

Also as mentioned in the README, CTRL-C to kill child processes also killed sheesh itself so I added a dummy SIGINT handler to fix that issue.